### PR TITLE
Update light 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ tags
 *.key
 
 # build folder for light
-i3-rest/light-*
+**/light-*
 
 # repository for oh-my-fish
 oh-my-fish/

--- a/rest/i3-light
+++ b/rest/i3-light
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-lightversion=1.1.2
+lightversion=1.2
 light=light-$lightversion
 
 # Light
-wget --content-disposition https://github.com/haikarainen/light/archive/$lightversion.tar.gz
+wget --content-disposition https://github.com/haikarainen/light/releases/download/v$lightversion/$light.tar.gz
 tar xf $light.tar.gz
 
 cd $light/
+./configure
 make
 sudo bash -c "make install"
 cd -


### PR DESCRIPTION
Updates light to the latest version, currently 1.2. The download link need to be updated.

Light is added gitignore.

Closes #14.